### PR TITLE
Add Visualize_and_mask notebook under wfci_notebooks

### DIFF
--- a/wfci_notebooks/Visualize_and_mask.ipynb
+++ b/wfci_notebooks/Visualize_and_mask.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cdaf8cf-e2eb-46f4-a17a-95f91d9c5e44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import masknmf\n",
+    "import fastplotlib as fpl\n",
+    "import tifffile\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "%load_ext autoreload\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2209485-fb4f-4f8d-ae64-ce9432fede62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Point to your dataset\n",
+    "#data = tifffile.imread(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9 Registration.npz\") # Shape (frames, height, width)\n",
+    "import numpy as np\n",
+    "\n",
+    "# Load the .npz archive\n",
+    "data = np.load(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9_Registration/run9E.npz\")\n",
+    "\n",
+    "\n",
+    "# Access the array\n",
+    "video = data['moco']  # (frames, height, width)\n",
+    "\n",
+    "# Get the mean image (or any other image you want)\n",
+    "mean_img = torch.from_numpy(np.mean(video, axis = 0)) #(Shape (height, width))\n",
+    "#mean_img = torch.tensor(np.mean(video, axis=0), dtype=torch.float32)\n",
+    "\n",
+    "\n",
+    "\n",
+    "'''\n",
+    "Define the transformation as a function that takes (frames, height, width) torch.tensor as input\n",
+    "and outputs a tensor of the same shape\n",
+    "'''\n",
+    "mean_sub = lambda x:x - mean_img[None, :, :]\n",
+    "\n",
+    "# Define an array object that describes this transformed dataset\n",
+    "mean_sub_array = masknmf.FilteredArray(video, \n",
+    "                                       mean_sub,\n",
+    "                                      device='cpu')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b67e7d6-fc43-40f0-9f33-a7adaa001eee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize this in imagewidget. \n",
+    "# Rendering speed depends on whether computations are performed on cpu/gpu and on whether the dataset is in RAM or not\n",
+    "iw = fpl.ImageWidget(data=[mean_sub_array, video, mean_img.numpy()],\n",
+    "                     names=None,\n",
+    "                     figure_shape=(1, 3))\n",
+    "\n",
+    "iw.cmap = \"gray\"\n",
+    "iw.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4021ee1d-9dcd-4bb8-94bd-2ed2ada05754",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Get the mean image to import into draw_mask.py to make mask\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.imsave(\"mean_image_for_mask_18.png\", mean_img.numpy(), cmap='gray') #Now locally load the mean with brain_mask.py\n",
+    "mean_img.shape\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7f770a4-c826-4c37-8d39-8c94def37a9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#After using draw_mask.py, load in binary brain mask and apply to data\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "\n",
+    "# Load the brain mask\n",
+    "brain_mask = torch.tensor(np.load(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9_Registration/resid_ac_zero_blood_mask_9.npy\")).float()\n",
+    "\n",
+    "# Apply it to the video\n",
+    "mask_brain = lambda x: x * brain_mask\n",
+    "masked_array = masknmf.FilteredArray(video, mask_brain, device='cpu')\n",
+    "\n",
+    "# Evaluate to NumPy array (no .cpu() needed!)\n",
+    "masked_np = masked_array[:]\n",
+    "\n",
+    "# Save to .npz\n",
+    "np.savez_compressed(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9_Registration/run9E_masked_blood.npz\", moco=masked_np)\n",
+    "print(\"✅ Saved masked video to masked_video.npz with key 'moco'\")\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90542187-b22e-4c2e-bc1b-dfaf1c088d68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Add the horizontal and vertical shifts from original moco data to masked data\n",
+    "import numpy as np\n",
+    "\n",
+    "# Load original file that contains 'shifts'\n",
+    "original_npz = np.load(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9_Registration/run9E.npz\")  # adjust name as needed\n",
+    "shifts = original_npz['shifts']\n",
+    "\n",
+    "# Load masked video that only has 'moco'\n",
+    "masked_npz = np.load(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9_Registration/run9E_masked_blood.npz\")\n",
+    "moco = masked_npz['moco']\n",
+    "\n",
+    "# Save both into a new file (or overwrite)\n",
+    "np.savez_compressed(\n",
+    "    \"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9_Registration/run9E_masked_shifts_blood.npz\",\n",
+    "    moco=moco,\n",
+    "    shifts=shifts\n",
+    ")\n",
+    "\n",
+    "print(\"✅ Masked video with 'shifts' saved.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15374717-9fa9-4e59-b8b5-89dd91fe629d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Point to your dataset\n",
+    "#data = tifffile.imread(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9 Registration.npz\") # Shape (frames, height, width)\n",
+    "import numpy as np\n",
+    "\n",
+    "# Load the .npz archive\n",
+    "data = np.load(\"/mnt/data1/vps2116/Widefield_MtlabOutputs/cm9999/cm9999_9_Registration/run9E_masked.npz\")\n",
+    "\n",
+    "\n",
+    "# Access the array\n",
+    "video_masked = data['moco']  # (frames, height, width)\n",
+    "\n",
+    "# Get the mean image (or any other image you want)\n",
+    "mean_img = torch.from_numpy(np.mean(video, axis = 0)) #(Shape (height, width))\n",
+    "#mean_img = torch.tensor(np.mean(video, axis=0), dtype=torch.float32)\n",
+    "\n",
+    "\n",
+    "\n",
+    "'''\n",
+    "Define the transformation as a function that takes (frames, height, width) torch.tensor as input\n",
+    "and outputs a tensor of the same shape\n",
+    "'''\n",
+    "mean_sub = lambda x:x - mean_img[None, :, :]\n",
+    "\n",
+    "# Define an array object that describes this transformed dataset\n",
+    "mean_sub_array = masknmf.FilteredArray(video, \n",
+    "                                       mean_sub,\n",
+    "                                      device='cpu')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08dbdfaa-ba29-46c2-bdab-f5d534324614",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize this in imagewidget. \n",
+    "# Rendering speed depends on whether computations are performed on cpu/gpu and on whether the dataset is in RAM or not\n",
+    "iw = fpl.ImageWidget(data=[mean_sub_array, video_masked, mean_img.numpy()],\n",
+    "                     names=None,\n",
+    "                     figure_shape=(1, 3))\n",
+    "\n",
+    "iw.cmap = \"gray\"\n",
+    "iw.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds `wfci_notebooks/Visualize_and_mask.ipynb`, a notebook for visualizing WFCI moco data and applying masks.
Outputs cleared to keep the diff small. No other files changed.


